### PR TITLE
Fixed incorrect behaviour of Makefile.

### DIFF
--- a/degree-thesis/en/Makefile
+++ b/degree-thesis/en/Makefile
@@ -1,5 +1,5 @@
-main.pdf: main.tex misc/setup.tex misc/titlepage.tex chapters/*.tex appendices/*.tex
-	lualatex main.tex && lualatex main.tex && biber main && lualatex main.tex
+main.pdf: main.tex misc/setup.tex misc/titlepage.tex chapters/*.tex appendices/*.tex literature.bib
+	lualatex main.tex && biber main && lualatex main.tex && lualatex main.tex
 
 clean:
 	latexmk -c && rm main.pdf && rm main.bbl && rm main.run.xml


### PR DESCRIPTION
- Added literature.bib as dependency to the Makefile because `make` did not recompile if only `literature.bib` was modified.
- Added `lualatex main.tex` a second time after calling `biber main` as page breaks might change and the page numbers in the References are only displayed after the second execution of 'lualatex`.