### PR TITLE
Citing more than two authors should use "et al."

### DIFF
--- a/degree-thesis/en/misc/setup.tex
+++ b/degree-thesis/en/misc/setup.tex
@@ -251,6 +251,7 @@
   sortcites=true,
   language=english,
   backref=true, % show on what pages a ref has been cited
+  maxcitenames=2, % how many names the \citeauthor will show
 ]{biblatex} % Use biber backend with alphabetic reference style
 \AtEveryBibitem{%
   \clearlist{language} % don't show "en."


### PR DESCRIPTION
According to the referenced literature ([Common Bugs in Writing][1], \#18), citing more than two authors should use "et al."

[1]: https://www.cs.columbia.edu/~hgs/etc/writing-bugs.html