### PR TITLE
\wideimage takes 4 arguments, not 5

### DIFF
--- a/degree-thesis/en/misc/commands.tex
+++ b/degree-thesis/en/misc/commands.tex
@@ -120,7 +120,7 @@
 % %%%%%%%%%%%%%%%%%%%%%%%
 % It seems this command messes with the position of other images, therefore it is advised to check the placement of other images.
 
-\newcommand{\wideimage}[5][t]{
+\newcommand{\wideimage}[4][t]{
 	\begin{figure*}[#1]
 		\includegraphics[width=\widefigurewidth]{../figures/#2}
 		\caption{\label{fig:#4}#3}


### PR DESCRIPTION
fix typo